### PR TITLE
Fix position state on subsequent `execute_command` calls

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -83,6 +83,7 @@ public:
 
   Position() = default;
   Position(const Position&) = delete;
+  Position(const std::string fenStr, bool isChess960, StateInfo* si, Thread* th) { set(fenStr, isChess960, si, th); }
   Position& operator=(const Position&) = delete;
 
   // FEN string input/output

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -234,7 +234,6 @@ namespace {
 void UCI::loop(int argc, char* argv[]) {
 
   string token, cmd;
-  StateListPtr states(new std::deque<StateInfo>(1));
 
   for (int i = 1; i < argc; ++i)
       cmd += std::string(argv[i]) + " ";
@@ -343,10 +342,9 @@ Move UCI::to_move(const Position& pos, string& str) {
 
 // Provides external command execution for UCI.
 void UCI::execute_command(const std::string &cmd) {
-  StateListPtr states(new std::deque<StateInfo>(1));
+  static StateListPtr states(new std::deque<StateInfo>(1));
   
-  Position pos;
-  pos.set(StartFEN, false, &states->back(), Threads.main());
+  static Position pos(StartFEN, false, &states->back(), Threads.main());
   
   istringstream is(cmd);
   string token;


### PR DESCRIPTION
* `execute_command` now maintains `states` and `pos` as `static` variables so their value is maintained on subsequent calls
* Previously the position was reset to the starting position every time `execute_command` was called